### PR TITLE
Add Supabase magic link proxy fallback to avoid fetch errors

### DIFF
--- a/index.html
+++ b/index.html
@@ -5945,46 +5945,128 @@
             document.getElementById('loginSuccessState').classList.remove('hidden');
         }
 
+        function shouldUseMagicLinkProxy(error) {
+            if (!error) return false;
+
+            const message = (error.message || '').toLowerCase();
+
+            return error.name === 'TypeError'
+                || message.includes('failed to fetch')
+                || message.includes('networkerror')
+                || message.includes('supabase sdk')
+                || message.includes('supabase is not defined')
+                || message.includes('supabase не инициализирован')
+                || message.includes('fetch failed')
+                || message.includes('could not fetch')
+                || message.includes('network request failed');
+        }
+
+        async function sendMagicLinkViaProxy(email) {
+            const response = await fetch('/api/send-magic-link.js', {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json'
+                },
+                body: JSON.stringify({
+                    email,
+                    redirectTo: window.location.origin + '/pages/account.html'
+                })
+            });
+
+            let data = null;
+            try {
+                data = await response.json();
+            } catch (parseError) {
+                data = null;
+            }
+
+            if (!response.ok || !data?.success) {
+                const message = data?.error || data?.message || `Сервер вернул статус ${response.status}`;
+                throw new Error(message);
+            }
+
+            return data;
+        }
+
         // Обработка формы входа
         document.addEventListener('DOMContentLoaded', function() {
             const loginForm = document.getElementById('loginForm');
             if (loginForm) {
                 loginForm.addEventListener('submit', async function(e) {
                     e.preventDefault();
-                    
-                    const email = document.getElementById('loginEmail').value;
+
+                    const emailInput = document.getElementById('loginEmail');
+                    const email = emailInput.value.trim();
                     const btn = document.getElementById('loginSubmitBtn');
                     const btnText = document.getElementById('loginBtnText');
                     const btnLoading = document.getElementById('loginBtnLoading');
-                    
+
                     try {
                         // Показываем состояние загрузки
                         btn.disabled = true;
                         btnText.classList.add('hidden');
                         btnLoading.classList.remove('hidden');
-                        
+
+                        if (!email) {
+                            throw new Error('Введите email для отправки ссылки');
+                        }
+
+                        let sent = false;
+                        let directError = null;
+
                         // Инициализируем Supabase если нужно
                         if (!supabaseClient) {
-                            await initSupabase();
-                        }
-                        
-                        // Отправляем Magic Link
-                        const { error } = await supabaseClient.auth.signInWithOtp({
-                            email: email,
-                            options: {
-                                emailRedirectTo: window.location.origin + '/pages/account.html'
+                            try {
+                                await initSupabase();
+                            } catch (initError) {
+                                directError = initError;
+                                console.warn('Не удалось инициализировать Supabase, используем резервный API отправки Magic Link', initError);
                             }
-                        });
-                        
-                        if (error) throw error;
-                        
+                        }
+
+                        if (supabaseClient) {
+                            try {
+                                const { error } = await supabaseClient.auth.signInWithOtp({
+                                    email: email,
+                                    options: {
+                                        emailRedirectTo: window.location.origin + '/pages/account.html',
+                                        shouldCreateUser: true
+                                    }
+                                });
+
+                                if (error) {
+                                    throw error;
+                                }
+
+                                sent = true;
+                            } catch (supabaseError) {
+                                directError = supabaseError;
+                                console.warn('Ошибка прямой отправки Magic Link, пробуем резервный API', supabaseError);
+
+                                if (!shouldUseMagicLinkProxy(supabaseError)) {
+                                    throw supabaseError;
+                                }
+                            }
+                        } else if (directError && !shouldUseMagicLinkProxy(directError)) {
+                            throw directError;
+                        }
+
+                        if (!sent) {
+                            await sendMagicLinkViaProxy(email);
+                            sent = true;
+                        }
+
+                        if (!sent) {
+                            throw new Error('Не удалось отправить ссылку. Попробуйте позже.');
+                        }
+
                         // Показываем успешное состояние
                         showSuccessState();
-                        
+
                     } catch (error) {
                         console.error('Ошибка отправки Magic Link:', error);
-                        alert('Ошибка отправки ссылки: ' + error.message);
-                        
+                        alert('Ошибка отправки ссылки: ' + (error.message || 'Неизвестная ошибка'));
+                    } finally {
                         // Возвращаем кнопку в исходное состояние
                         btn.disabled = false;
                         btnText.classList.remove('hidden');

--- a/pages/account.html
+++ b/pages/account.html
@@ -1837,52 +1837,130 @@
 
 
         // Handle login form submission
+        function shouldUseMagicLinkProxy(error) {
+            if (!error) return false;
+
+            const message = (error.message || '').toLowerCase();
+
+            return error.name === 'TypeError'
+                || message.includes('failed to fetch')
+                || message.includes('networkerror')
+                || message.includes('supabase sdk')
+                || message.includes('supabase is not defined')
+                || message.includes('supabase не инициализирован')
+                || message.includes('fetch failed')
+                || message.includes('could not fetch')
+                || message.includes('network request failed');
+        }
+
+        function getMagicLinkRedirectUrl() {
+            try {
+                const origin = window.location?.origin || 'https://www.svetsalonpro.ru';
+                return `${origin.replace(/\/$/, '')}/pages/account.html`;
+            } catch (error) {
+                return 'https://www.svetsalonpro.ru/pages/account.html';
+            }
+        }
+
+        async function sendMagicLinkViaProxy(email) {
+            const response = await fetch('/api/send-magic-link.js', {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json'
+                },
+                body: JSON.stringify({
+                    email,
+                    redirectTo: getMagicLinkRedirectUrl()
+                })
+            });
+
+            let data = null;
+            try {
+                data = await response.json();
+            } catch (parseError) {
+                data = null;
+            }
+
+            if (!response.ok || !data?.success) {
+                const message = data?.error || data?.message || `Сервер вернул статус ${response.status}`;
+                throw new Error(message);
+            }
+
+            return data;
+        }
+
         function setupLoginForm() {
             console.log('Настраиваем форму входа...');
-            
+
             const loginForm = document.getElementById('loginForm');
-            
+
             if (loginForm) {
                 loginForm.addEventListener('submit', async (e) => {
                     e.preventDefault();
                     console.log('Форма отправлена!');
-                    
-                    const email = document.getElementById('email').value;
+
+                    const emailInput = document.getElementById('email');
+                    const email = emailInput.value.trim();
                     const loginBtn = document.getElementById('loginBtn');
                     const loginBtnText = document.getElementById('loginBtnText');
                     const loginBtnLoading = document.getElementById('loginBtnLoading');
-                    
+
                     try {
                         console.log('Отправляем Magic Link на email:', email);
-                        
+
                         // Show loading state
                         loginBtn.disabled = true;
                         loginBtnText.classList.add('hidden');
                         loginBtnLoading.classList.remove('hidden');
-                        
-                        // Проверяем, что Supabase инициализирован
-                        const client = window.supabaseClient || supabaseClient;
-                        if (!client || !client.auth) {
-                            throw new Error('Supabase не инициализирован. Попробуйте обновить страницу.');
+
+                        if (!email) {
+                            throw new Error('Введите email для отправки ссылки.');
                         }
-                        
-                        // Отправляем Magic Link
-                        const { error } = await client.auth.signInWithOtp({
-                            email: email,
-                            options: {
-                                emailRedirectTo: 'https://www.svetsalonpro.ru/pages/account.html',
-                                shouldCreateUser: true
+
+                        let sent = false;
+                        const client = window.supabaseClient || supabaseClient;
+
+                        if (client && client.auth) {
+                            try {
+                                const { error } = await client.auth.signInWithOtp({
+                                    email: email,
+                                    options: {
+                                        emailRedirectTo: 'https://www.svetsalonpro.ru/pages/account.html',
+                                        shouldCreateUser: true
+                                    }
+                                });
+
+                                if (error) {
+                                    throw error;
+                                }
+
+                                sent = true;
+                            } catch (supabaseError) {
+                                console.warn('Ошибка прямой отправки Magic Link, пробуем резервный API', supabaseError);
+
+                                if (!shouldUseMagicLinkProxy(supabaseError)) {
+                                    throw supabaseError;
+                                }
                             }
-                        });
-                        
-                        if (error) throw error;
-                        
+                        } else {
+                            console.warn('Supabase клиент недоступен, используем резервный API для отправки Magic Link');
+                        }
+
+                        if (!sent) {
+                            await sendMagicLinkViaProxy(email);
+                            sent = true;
+                        }
+
+                        if (!sent) {
+                            throw new Error('Не удалось отправить ссылку. Попробуйте позже.');
+                        }
+
                         // Show success message
                         showNotification('success', 'Ссылка отправлена!', 'Ссылка для входа отправлена на ваш email!');
-                        
+
                     } catch (error) {
                         console.error('Magic Link error:', error);
-                        showNotification('error', 'Ошибка отправки', error.message);
+                        showNotification('error', 'Ошибка отправки', error.message || 'Не удалось отправить ссылку. Попробуйте позже.');
                     } finally {
                         // Reset button state
                         loginBtn.disabled = false;

--- a/pages/api/send-magic-link.js
+++ b/pages/api/send-magic-link.js
@@ -1,0 +1,185 @@
+const SUPABASE_CONFIG = require('../../supabase-config.js');
+
+const SUPABASE_URL = (SUPABASE_CONFIG?.url || '').replace(/\/+$/, '');
+const SUPABASE_ANON_KEY = SUPABASE_CONFIG?.anonKey || '';
+const DEFAULT_REDIRECT = SUPABASE_CONFIG?.auth?.redirectTo || 'https://www.svetsalonpro.ru/pages/account.html';
+const MAGIC_LINK_ENDPOINT = SUPABASE_URL ? `${SUPABASE_URL}/auth/v1/magiclink` : null;
+
+const ALLOWED_REDIRECT_HOSTS = new Set([
+    'www.svetsalonpro.ru',
+    'svetsalonpro.ru',
+    'localhost',
+    '127.0.0.1'
+]);
+
+const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/i;
+
+function normalizeAccountPath(url) {
+    const normalized = new URL(url.toString());
+    if (normalized.pathname !== '/pages/account.html') {
+        normalized.pathname = '/pages/account.html';
+        normalized.search = '';
+        normalized.hash = '';
+    }
+    return normalized.toString();
+}
+
+function resolveRedirectUrl(req, providedRedirect) {
+    const fallback = (() => {
+        try {
+            const fallbackUrl = new URL(DEFAULT_REDIRECT);
+            return normalizeAccountPath(fallbackUrl);
+        } catch (error) {
+            return 'https://www.svetsalonpro.ru/pages/account.html';
+        }
+    })();
+
+    const tryParse = (value) => {
+        if (!value) return null;
+        try {
+            const candidate = new URL(value);
+            if (!ALLOWED_REDIRECT_HOSTS.has(candidate.hostname)) {
+                return null;
+            }
+            return normalizeAccountPath(candidate);
+        } catch (error) {
+            return null;
+        }
+    };
+
+    const fromBody = tryParse(providedRedirect);
+    if (fromBody) {
+        return fromBody;
+    }
+
+    const host = req?.headers?.host;
+    if (host) {
+        const protocol = host.includes('localhost') || host.includes('127.0.0.1') ? 'http' : 'https';
+        const originCandidate = `${protocol}://${host}/pages/account.html`;
+        const resolved = tryParse(originCandidate);
+        if (resolved) {
+            return resolved;
+        }
+    }
+
+    const originHeader = req?.headers?.origin;
+    if (originHeader) {
+        const resolved = tryParse(`${originHeader.replace(/\/$/, '')}/pages/account.html`);
+        if (resolved) {
+            return resolved;
+        }
+    }
+
+    return fallback;
+}
+
+async function forwardMagicLink(email, redirectUrl) {
+    if (!MAGIC_LINK_ENDPOINT || !SUPABASE_ANON_KEY) {
+        const error = new Error('Supabase configuration is missing');
+        error.status = 500;
+        throw error;
+    }
+
+    const response = await fetch(MAGIC_LINK_ENDPOINT, {
+        method: 'POST',
+        headers: {
+            'Content-Type': 'application/json',
+            'Accept': 'application/json',
+            'apikey': SUPABASE_ANON_KEY,
+            'Authorization': `Bearer ${SUPABASE_ANON_KEY}`
+        },
+        body: JSON.stringify({
+            email,
+            redirect_to: redirectUrl,
+            should_create_user: true
+        })
+    });
+
+    const contentType = response.headers.get('content-type') || '';
+    const isJson = contentType.includes('application/json');
+    const payload = isJson ? await response.json() : await response.text();
+
+    if (!response.ok) {
+        const message = typeof payload === 'string'
+            ? payload
+            : payload?.msg || payload?.error_description || payload?.error || payload?.message || 'Не удалось отправить ссылку';
+
+        const error = new Error(message);
+        error.status = response.status;
+        error.payload = payload;
+        throw error;
+    }
+
+    return payload;
+}
+
+function handleRequest(req, res) {
+    if (req.method !== 'POST') {
+        res.writeHead(405, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ success: false, error: 'Method not allowed' }));
+        return;
+    }
+
+    let rawBody = '';
+
+    req.on('data', (chunk) => {
+        rawBody += chunk.toString();
+    });
+
+    req.on('error', (error) => {
+        console.error('Error reading magic link request body:', error);
+        res.writeHead(400, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ success: false, error: 'Некорректный запрос' }));
+    });
+
+    req.on('end', async () => {
+        let payload = {};
+
+        if (rawBody.trim().length > 0) {
+            try {
+                payload = JSON.parse(rawBody);
+            } catch (error) {
+                res.writeHead(400, { 'Content-Type': 'application/json' });
+                res.end(JSON.stringify({ success: false, error: 'Тело запроса должно быть в формате JSON' }));
+                return;
+            }
+        }
+
+        const email = (payload.email || '').toString().trim().toLowerCase();
+
+        if (!EMAIL_REGEX.test(email)) {
+            res.writeHead(400, { 'Content-Type': 'application/json' });
+            res.end(JSON.stringify({ success: false, error: 'Укажите корректный email' }));
+            return;
+        }
+
+        const redirectUrl = resolveRedirectUrl(req, payload.redirectTo || payload.redirect_to);
+
+        try {
+            await forwardMagicLink(email, redirectUrl);
+
+            res.writeHead(200, { 'Content-Type': 'application/json' });
+            res.end(JSON.stringify({
+                success: true,
+                message: 'Ссылка для входа отправлена на email',
+                redirectTo: redirectUrl
+            }));
+        } catch (error) {
+            console.error('Magic link proxy error:', error);
+            const statusCode = Number.isInteger(error.status) ? error.status : 502;
+            const responseBody = {
+                success: false,
+                error: error.message || 'Не удалось отправить ссылку'
+            };
+
+            if (error.payload && typeof error.payload === 'object' && Object.keys(error.payload).length > 0) {
+                responseBody.details = error.payload;
+            }
+
+            res.writeHead(statusCode, { 'Content-Type': 'application/json' });
+            res.end(JSON.stringify(responseBody));
+        }
+    });
+}
+
+module.exports = { handleRequest };

--- a/server.js
+++ b/server.js
@@ -12,6 +12,7 @@ const uploadPhotosAPI = require('./pages/api/upload-photos.js');
 // Импортируем API для SMS-кода
 const sendSmsCodeAPI = require('./pages/api/send-sms-code.js');
 const verifySmsCodeAPI = require('./pages/api/verify-sms-code.js');
+const sendMagicLinkAPI = require('./pages/api/send-magic-link.js');
 
 // MIME типы для статических файлов
 const mimeTypes = {
@@ -56,10 +57,16 @@ const server = http.createServer((req, res) => {
         sendSmsCodeAPI.handleRequest(req, res);
         return;
     }
-    
+
     // Обработка API запросов для проверки SMS-кода
     if (pathname === '/api/verify-sms-code.js' || pathname === '/pages/api/verify-sms-code.js') {
         verifySmsCodeAPI.handleRequest(req, res);
+        return;
+    }
+
+    // Обработка API запросов для отправки Magic Link через Supabase
+    if (pathname === '/api/send-magic-link.js' || pathname === '/pages/api/send-magic-link.js') {
+        sendMagicLinkAPI.handleRequest(req, res);
         return;
     }
     

--- a/server.js
+++ b/server.js
@@ -46,25 +46,25 @@ const server = http.createServer((req, res) => {
         return;
     }
     
-    // Обработка API запросов для загрузки фотографий
+    // Обработка API запросов на загрузку фотографий
     if (pathname === '/api/upload-photos.js' || pathname === '/pages/api/upload-photos.js') {
         uploadPhotosAPI.handleRequest(req, res);
         return;
     }
     
-    // Обработка API запросов для отправки SMS-кода
+    // Обработка API запросов на отправку SMS-кода
     if (pathname === '/api/send-sms-code.js' || pathname === '/pages/api/send-sms-code.js') {
         sendSmsCodeAPI.handleRequest(req, res);
         return;
     }
 
-    // Обработка API запросов для проверки SMS-кода
+    // Обработка API запросов на проверку SMS-кода
     if (pathname === '/api/verify-sms-code.js' || pathname === '/pages/api/verify-sms-code.js') {
         verifySmsCodeAPI.handleRequest(req, res);
         return;
     }
 
-    // Обработка API запросов для отправки Magic Link через Supabase
+    // Обработка API запросов на отправку Magic Link через Supabase
     if (pathname === '/api/send-magic-link.js' || pathname === '/pages/api/send-magic-link.js') {
         sendMagicLinkAPI.handleRequest(req, res);
         return;


### PR DESCRIPTION
## Summary
- add a server-side proxy endpoint that forwards magic link requests to Supabase using the existing configuration
- update the public and account login forms to fall back to the proxy when direct Supabase requests fail and improve validation and messaging
- wire the new API route into the Node server alongside the existing endpoints

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68cb2c3f7be48323b1697efb55d35c9a