### PR TITLE
Make header logo open homepage

### DIFF
--- a/index.html
+++ b/index.html
@@ -2080,8 +2080,8 @@
         <div class="container mx-auto px-4">
             <div class="flex items-center justify-between h-16">
                 <!-- Logo -->
-                <div class="flex items-center space-x-4">
-                    <div class="w-10 h-10 bg-gradient-to-br from-pink-500 to-purple-600 rounded-xl flex items-center justify-center shadow-lg">
+                <a href="index.html" class="flex items-center space-x-4 group" aria-label="Перейти на главную страницу">
+                    <div class="w-10 h-10 bg-gradient-to-br from-pink-500 to-purple-600 rounded-xl flex items-center justify-center shadow-lg transition-transform duration-200 group-hover:scale-105 group-hover:shadow-xl">
                         <i class="fas fa-spa text-white text-lg"></i>
                     </div>
                     <div>
@@ -2090,7 +2090,7 @@
                         </h1>
                         <p class="text-xs text-gray-500 -mt-1">Салон красоты</p>
                     </div>
-                </div>
+                </a>
 
                 <!-- Navigation -->
                 <nav class="hidden md:flex items-center space-x-8">
@@ -3721,8 +3721,11 @@
     <script>
     document.querySelectorAll('.logo-link').forEach(function(logo) {
       logo.addEventListener('click', function(e) {
-        e.preventDefault();
-        window.scrollTo({ top: 0, behavior: 'smooth' });
+        const href = logo.getAttribute('href');
+        if (!href || href.trim() === '' || href === '#') {
+          e.preventDefault();
+          window.scrollTo({ top: 0, behavior: 'smooth' });
+        }
       });
     });
     </script>

--- a/pages/portfolio.html
+++ b/pages/portfolio.html
@@ -527,9 +527,11 @@
                     <div class="w-10 h-10 bg-gradient-to-br from-pink-500 to-purple-600 rounded-xl flex items-center justify-center shadow-lg transition-transform duration-200 group-hover:scale-105 group-hover:shadow-xl">
                         <i class="fas fa-spa text-white text-lg"></i>
                     </div>
-                    <div class="flex flex-col">
-                        <span class="text-xl font-bold bg-gradient-to-r from-pink-600 to-purple-600 bg-clip-text text-transparent leading-none">SvetSalonPro</span>
-                        <span class="text-xs text-gray-500 -mt-1">Салон красоты</span>
+                    <div>
+                        <h1 class="text-xl font-bold bg-gradient-to-r from-pink-600 to-purple-600 bg-clip-text text-transparent">
+                            SvetSalonPro
+                        </h1>
+                        <p class="text-xs text-gray-500 -mt-1">Салон красоты</p>
                     </div>
                 </a>
 

--- a/pages/portfolio.html
+++ b/pages/portfolio.html
@@ -523,17 +523,15 @@
         <div class="container mx-auto px-4">
             <div class="flex items-center justify-between h-16">
                 <!-- Logo -->
-                <div class="flex items-center space-x-4">
-                    <div class="w-10 h-10 bg-gradient-to-br from-pink-500 to-purple-600 rounded-xl flex items-center justify-center shadow-lg">
+                <a href="../index.html" class="flex items-center space-x-4 group" aria-label="Перейти на главную страницу">
+                    <div class="w-10 h-10 bg-gradient-to-br from-pink-500 to-purple-600 rounded-xl flex items-center justify-center shadow-lg transition-transform duration-200 group-hover:scale-105 group-hover:shadow-xl">
                         <i class="fas fa-spa text-white text-lg"></i>
                     </div>
-                    <div>
-                        <a href="../index.html" class="flex flex-col">
-                            <span class="text-xl font-bold bg-gradient-to-r from-pink-600 to-purple-600 bg-clip-text text-transparent leading-none">SvetSalonPro</span>
-                            <span class="text-xs text-gray-500 -mt-1">Салон красоты</span>
-                        </a>
+                    <div class="flex flex-col">
+                        <span class="text-xl font-bold bg-gradient-to-r from-pink-600 to-purple-600 bg-clip-text text-transparent leading-none">SvetSalonPro</span>
+                        <span class="text-xs text-gray-500 -mt-1">Салон красоты</span>
                     </div>
-                </div>
+                </a>
 
                 <!-- Navigation -->
                 <nav class="hidden md:flex items-center space-x-8">


### PR DESCRIPTION
## Summary
- wrap the main header logo and title in a home link on the landing page
- make the portfolio header logo take visitors back to the main page with matching hover feedback
- adjust the logo-link helper script so real links keep navigating while placeholder logos still scroll to top

## Testing
- not run (static HTML site)


------
https://chatgpt.com/codex/tasks/task_e_68cb3a011f8483238c71fb6b5503c3f1